### PR TITLE
ci: update deprecated GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 16
+          node-version: 20
       - name: Install dependencies
         run: npm install
       - run: npx semantic-release


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v2 → v6.0.2
- Upgrade `actions/setup-node` v2 → v6.3.0
- Upgrade `node-version` from 16 to 20
- Pin external actions to commit hashes for security, with version comments for Dependabot

Resolves GitHub Actions Node.js deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)